### PR TITLE
fix: Make make_dss_pip follow HTTP redirects

### DIFF
--- a/make_dss_pip.sh
+++ b/make_dss_pip.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
-VERSION=$(curl -v --silent https://www.dataiku.com/dss/trynow/linux/ 2>&1 | grep -e 'var cur_version' | sed -n 's/^.*"\(.*\)".*$/\1/p')
+VERSION=$(curl -L -v --silent https://www.dataiku.com/dss/trynow/linux/ 2>&1 | grep -e 'var cur_version' | sed -n 's/^.*"\(.*\)".*$/\1/p')
+
+if [ -z "$VERSION" ]; then
+  echo "Can't find a DSS version"
+  exit
+fi
 
 mkdir -p lib
 


### PR DESCRIPTION
Closes #9

The `./make_dss_pip.sh` step fails because Dataiku changed the download page for Dataiku. Instead of updating to the new one, this change just allows the script to follow the direct (and then causes it to fail if it can't find a version).