### PR TITLE
fix(AOBS-491): Handle TIMESTAMP and separate tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ Second, use the `pip` command from the previous step to install the package in t
 2. In PyCharm, run the _Unit Tests_ configuration.
 
 ## Known Issues
-* Neither Snowflake nor Dataiku use [Logical Type annotations](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#datetime-types) for timezone offsets (Dataiku doesn't use Logical Types at all). When synching from Snowflake to HDFS, the plugin casts any `TIMESTAMP_TZ` or `TIMESTAMP_LTZ` columns to `TIMESTAMP_NTZ` which simply drops the timezone offset attribute. For greater control of this behaviour, transform your Snowflake table before passing it to this plugin. Consider using `CONVERT_TIMEZONE('UTC', t."date")::TIMESTAMP_NTZ`.
-  See [Date & Time Data Types in Snowflake](https://docs.snowflake.com/en/sql-reference/data-types-datetime.html) for more details.
-* Snowflake stores all `TIMESTAMP_NTZ` and `DATE` columns as annotated logical types in Parquet. Because Dataiku does not support logical types, these appear in Dataiku as `bigint` (`int64` as `datetime`) and `int` (`int32` as `date`). More details and workarounds are described in #12 
-  See [this article](https://bigpicture.pl/blog/2017/11/timestamps-parquet-hadoop/#:~:text=Timestamp%20in%20Hive&text=They%20are%20interpreted%20as%20timestamps,depends%20on%20the%20file%20format.) for more details about Timestamp in Parquet.
+
+* Neither Snowflake nor Dataiku use [Logical Type annotations](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#datetime-types) for timezone offsets (Dataiku doesn't use Logical Types at all). When synching from Snowflake to HDFS, the plugin casts any `TIMESTAMP_TZ` or `TIMESTAMP_LTZ` columns to `TIMESTAMP_NTZ` which simply drops the timezone offset attribute. For greater control of this behaviour, transform your Snowflake table before passing it to this plugin. Consider using `CONVERT_TIMEZONE('UTC', t."date")::TIMESTAMP_NTZ`. See [Date & Time Data Types in Snowflake](https://docs.snowflake.com/en/sql-reference/data-types-datetime.html) for more details.
+* Snowflake stores all `TIMESTAMP_NTZ` and `DATE` columns as annotated logical types in Parquet. Because Dataiku does not support logical types, these appear in Dataiku as `bigint` (`int64` as `datetime`) and `int` (`int32` as `date`). More details and workarounds are described in #12
+
 
 ## TODO
 
@@ -92,3 +92,5 @@ Second, use the `pip` command from the previous step to install the package in t
 - [ ] For Snowflake to HDFS, delete the *.parquet.snappy file in the output path (it's the one created when inserting the empty dataframe)
 - [ ] Support more types than Parquet (e.g., `CSV`, `AVRO`, etc.)
 - [ ] Verify that the HDFS connection is actually an S3 location (possibly the best way to enforce the `STAGE` lining up to HDFS)
+- [ ] Implement workarounds for #12
+- [ ] Convert TS columns to UTC using `CONVERT_TIMEZONE`

--- a/python-lib/config.py
+++ b/python-lib/config.py
@@ -95,10 +95,13 @@ def get_snowflake_to_hdfs_query(sf_location: AnyStr, sf_table_name: AnyStr,
     # things significantly easier to unit test.
 
     # Generate SELECT clause and cast TIMESTAMP_TZ, TIMESTAMP_LTZ to TIMESTAMP_NTZ
+    # Also cast TIMESTAMP because users can override TIMESTAMP to actually mean TIMESTAMP_TZ per
+    # documentation: https://docs.snowflake.com/en/sql-reference/parameters.html#client-timestamp-type-mapping
     # This is required as the COPY command does not support TZ and LTZ
+    timezoned_types = ['TIMESTAMPLTZ', 'TIMESTAMPTZ', 'TIMESTAMP']
     columns = [
         f'"{c["name"]}"'
-        + (f'::TIMESTAMP_NTZ AS "{c["name"]}"' if c['originalType'] in ['TIMESTAMPLTZ', 'TIMESTAMPTZ'] else '')
+        + (f'::TIMESTAMP_NTZ AS "{c["name"]}"' if c['originalType'] in timezoned_types else '')
         for c in sf_schema
     ]
 


### PR DESCRIPTION
Following @czen88 's identification of a `CLIENT_TIMESTAMP_TYPE_MAPPING` edge case, this pull request addresses the case where a user may have set `TIMESTAMP` to mean `TIMESTAMP_TZ` via `CLIENT_TIMESTAMP_TYPE_MAPPING`.

Additionally, following the existing HDFS &rarr; SF tests' pattern, this PR separates the `get_snowflake_to_hdfs_query` tests in to a query creation test and a column casting test.
