### PR TITLE
AOBS-491: Fix for TIMESTAMP_TZ and TIMESTAMP_LTZ

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Second, use the `pip` command from the previous step to install the package in t
 2. In PyCharm, run the _Unit Tests_ configuration.
 
 ## Known Issues
-+ Currently Parquet does not support TIMESTAMP_TZ and TIMESTAMP_LTZ data types so they are converted to TIMESTAMP_NTZ.
+* Neither Snowflake nor Dataiku use [Logical Type annotations](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#datetime-types) for timezone offsets (Dataiku doesn't use Logical Types at all). When synching from Snowflake to HDFS, the plugin casts any `TIMESTAMP_TZ` or `TIMESTAMP_LTZ` columns to `TIMESTAMP_NTZ` which simply drops the timezone offset attribute. For greater control of this behaviour, transform your Snowflake table before passing it to this plugin. Consider using `CONVERT_TIMEZONE('UTC', t."date")::TIMESTAMP_NTZ`.
   As a result timezone details are removed from the TIMESTAMP. See [Date & Time Data Types in Snowflake](https://docs.snowflake.com/en/sql-reference/data-types-datetime.html) for more details.
 + All TIMESTAMP (LTZ, TZ, NTZ) and DATE columns from Snowflake are stored as INTEGER in Parquet.
   See [this article](https://bigpicture.pl/blog/2017/11/timestamps-parquet-hadoop/#:~:text=Timestamp%20in%20Hive&text=They%20are%20interpreted%20as%20timestamps,depends%20on%20the%20file%20format.) for more details about Timestamp in Parquet.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Second, use the `pip` command from the previous step to install the package in t
 ## Known Issues
 * Neither Snowflake nor Dataiku use [Logical Type annotations](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#datetime-types) for timezone offsets (Dataiku doesn't use Logical Types at all). When synching from Snowflake to HDFS, the plugin casts any `TIMESTAMP_TZ` or `TIMESTAMP_LTZ` columns to `TIMESTAMP_NTZ` which simply drops the timezone offset attribute. For greater control of this behaviour, transform your Snowflake table before passing it to this plugin. Consider using `CONVERT_TIMEZONE('UTC', t."date")::TIMESTAMP_NTZ`.
   See [Date & Time Data Types in Snowflake](https://docs.snowflake.com/en/sql-reference/data-types-datetime.html) for more details.
-+ All TIMESTAMP (LTZ, TZ, NTZ) and DATE columns from Snowflake are stored as INTEGER in Parquet.
+* Snowflake stores all `TIMESTAMP_NTZ` and `DATE` columns as annotated logical types in Parquet. Because Dataiku does not support logical types, these appear in Dataiku as `bigint` (`int64` as `datetime`) and `int` (`int32` as `date`). More details and workarounds are described in #12 
   See [this article](https://bigpicture.pl/blog/2017/11/timestamps-parquet-hadoop/#:~:text=Timestamp%20in%20Hive&text=They%20are%20interpreted%20as%20timestamps,depends%20on%20the%20file%20format.) for more details about Timestamp in Parquet.
 
 ## TODO

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ CREATE OR REPLACE STAGE YOUR_ACCOUNT_DATAIKU_EMR_MANAGED_STAGE
 GRANT USAGE ON YOUR_ACCOUNT_DATAIKU_EMR_MANAGED_STAGE TO DSS_SF_ROLE_NAME;
 ```
 
-Note that this example uses an [AWS IAM role](https://docs.snowflake.net/manuals/user-guide/data-load-s3-config.html#option-2-configuring-an-aws-iam-role) for securing the stage's connection to your S3 bucket. There's no reason a stage secured using AWS access keys wouldn't work, but it has not been tested. 
+Note that this example uses an [AWS IAM role](https://docs.snowflake.net/manuals/user-guide/data-load-s3-config.html#option-2-configuring-an-aws-iam-role) for securing the stage's connection to your S3 bucket. There's no reason a stage secured using AWS access keys wouldn't work, but it has not been tested.
 
 
 ## Installing
@@ -38,7 +38,7 @@ Or, you can create a Zip file and following [these instructions](https://doc.dat
 
 You can (optionally) configure a _Default Snowflake Stage_ in the plugin's settings. For example, the `STAGE` created above would be entered as `@PUBLIC.YOUR_ACCOUNT_DATAIKU_EMR_MANAGED_STAGE`.
 
-When using the recipe, you can override the default stage in the _Snowflake Stage_ setting. 
+When using the recipe, you can override the default stage in the _Snowflake Stage_ setting.
 
 ## Usage
 
@@ -63,6 +63,8 @@ When using the recipe, you can override the default stage in the _Snowflake Stag
 7. Click _Run_
 
 ## Building in PyCharm
+
+Make sure that wget is installed. For Mac run `brew install wget` to install wget.
 
 Custom Recipe libraries aren't included in DSS's `dataiku-internal-client` package so we need to fake it 'til we make it.
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Second, use the `pip` command from the previous step to install the package in t
 1. Make sure you can build the project by doing all of the `pip` steps above
 2. In PyCharm, run the _Unit Tests_ configuration.
 
+## Known Issues
++ All TIMESTAMP (LTZ, TZ, NTZ) and DATE columns from Snowflake are stored as [Unix Timestamp](https://www.unixtimestamp.com/) in Parquet.
+  This is currently recognised as int by Dataiku and will need extra parsing.
+
 ## TODO
 
 - [x] When Snowflake is an input, check that it's a table and not a query

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Second, use the `pip` command from the previous step to install the package in t
 
 ## Known Issues
 * Neither Snowflake nor Dataiku use [Logical Type annotations](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#datetime-types) for timezone offsets (Dataiku doesn't use Logical Types at all). When synching from Snowflake to HDFS, the plugin casts any `TIMESTAMP_TZ` or `TIMESTAMP_LTZ` columns to `TIMESTAMP_NTZ` which simply drops the timezone offset attribute. For greater control of this behaviour, transform your Snowflake table before passing it to this plugin. Consider using `CONVERT_TIMEZONE('UTC', t."date")::TIMESTAMP_NTZ`.
-  As a result timezone details are removed from the TIMESTAMP. See [Date & Time Data Types in Snowflake](https://docs.snowflake.com/en/sql-reference/data-types-datetime.html) for more details.
+  See [Date & Time Data Types in Snowflake](https://docs.snowflake.com/en/sql-reference/data-types-datetime.html) for more details.
 + All TIMESTAMP (LTZ, TZ, NTZ) and DATE columns from Snowflake are stored as INTEGER in Parquet.
   See [this article](https://bigpicture.pl/blog/2017/11/timestamps-parquet-hadoop/#:~:text=Timestamp%20in%20Hive&text=They%20are%20interpreted%20as%20timestamps,depends%20on%20the%20file%20format.) for more details about Timestamp in Parquet.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ When using the recipe, you can override the default stage in the _Snowflake Stag
 
 ## Building in PyCharm
 
-Make sure that wget is installed. For Mac run `brew install wget` to install wget.
+Make sure that [wget](https://www.gnu.org/software/wget/) is installed. For macOS, you can install via `brew install wget`.
 
 Custom Recipe libraries aren't included in DSS's `dataiku-internal-client` package so we need to fake it 'til we make it.
 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,10 @@ Second, use the `pip` command from the previous step to install the package in t
 2. In PyCharm, run the _Unit Tests_ configuration.
 
 ## Known Issues
-+ All TIMESTAMP (LTZ, TZ, NTZ) and DATE columns from Snowflake are stored as [Unix Timestamp](https://www.unixtimestamp.com/) in Parquet.
-  This is currently recognised as int by Dataiku and will need extra parsing.
++ Currently Parquet does not support TIMESTAMP_TZ and TIMESTAMP_LTZ data types so they are converted to TIMESTAMP_NTZ.
+  As a result timezone details are removed from the TIMESTAMP. See [Date & Time Data Types in Snowflake](https://docs.snowflake.com/en/sql-reference/data-types-datetime.html) for more details.
++ All TIMESTAMP (LTZ, TZ, NTZ) and DATE columns from Snowflake are stored as INTEGER in Parquet.
+  See [this article](https://bigpicture.pl/blog/2017/11/timestamps-parquet-hadoop/#:~:text=Timestamp%20in%20Hive&text=They%20are%20interpreted%20as%20timestamps,depends%20on%20the%20file%20format.) for more details about Timestamp in Parquet.
 
 ## TODO
 

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,5 +1,5 @@
 {
-  "acceptedPythonInterpreters": ["PYTHON34","PYTHON35","PYTHON36","PYTHON37"],
+  "acceptedPythonInterpreters": ["PYTHON35","PYTHON36","PYTHON37"],
   "forceConda": false,
   "installCorePackages": true,
   "installJupyterSupport": true

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,5 +1,5 @@
 {
-  "acceptedPythonInterpreters": ["PYTHON34","PYTHON35","PYTHON36"],
+  "acceptedPythonInterpreters": ["PYTHON34","PYTHON35","PYTHON36","PYTHON37"],
   "forceConda": false,
   "installCorePackages": true,
   "installJupyterSupport": true

--- a/custom-recipes/sync_snowflake_to_hdfs/recipe.py
+++ b/custom-recipes/sync_snowflake_to_hdfs/recipe.py
@@ -31,11 +31,12 @@ with hdfs_output.get_writer():
     pass
 
 executor = SQLExecutor2(connection=sf_connection_name)
-sh = get_table_schema(sf_table_name, executor)
+sql = get_table_schema_sql(sf_table_name)
+logger.info(f'Table schema query: {sql}')
+sh = executor.query_to_df(sql).to_dict('records')
+
 sql = get_snowflake_to_hdfs_query(sf_location, sf_table_name, sh)
-
 logger.info(f'SF Query: {sql}')
-
 results = executor.query_to_df(sql)
 
 logger.info(f'COPY results: ${results.to_string()}')

--- a/custom-recipes/sync_snowflake_to_hdfs/recipe.py
+++ b/custom-recipes/sync_snowflake_to_hdfs/recipe.py
@@ -30,7 +30,7 @@ hdfs_output.write_schema(sf_input.read_schema(), dropAndCreate=True)
 with hdfs_output.get_writer():
     pass
 
-sql = get_snowflake_to_hdfs_query(sf_location, sf_table_name)
+sql = get_snowflake_to_hdfs_query(sf_location, sf_table_name, sf_input_config['schema']['columns'])
 
 logger.info(f'SF Query: {sql}')
 

--- a/custom-recipes/sync_snowflake_to_hdfs/recipe.py
+++ b/custom-recipes/sync_snowflake_to_hdfs/recipe.py
@@ -30,7 +30,7 @@ hdfs_output.write_schema(sf_input.read_schema(), dropAndCreate=True)
 with hdfs_output.get_writer():
     pass
 
-sql = get_snowflake_to_hdfs_query(sf_location, sf_table_name, sf_input_config['schema']['columns'])
+sql = get_snowflake_to_hdfs_query(sf_location, sf_table_name, sf_input.read_schema())
 
 logger.info(f'SF Query: {sql}')
 

--- a/custom-recipes/sync_snowflake_to_hdfs/recipe.py
+++ b/custom-recipes/sync_snowflake_to_hdfs/recipe.py
@@ -30,11 +30,12 @@ hdfs_output.write_schema(sf_input.read_schema(), dropAndCreate=True)
 with hdfs_output.get_writer():
     pass
 
-sql = get_snowflake_to_hdfs_query(sf_location, sf_table_name, sf_input.read_schema())
+executor = SQLExecutor2(connection=sf_connection_name)
+sh = get_table_schema(sf_table_name, executor)
+sql = get_snowflake_to_hdfs_query(sf_location, sf_table_name, sh)
 
 logger.info(f'SF Query: {sql}')
 
-executor = SQLExecutor2(connection=sf_connection_name)
 results = executor.query_to_df(sql)
 
 logger.info(f'COPY results: ${results.to_string()}')

--- a/python-lib/config.py
+++ b/python-lib/config.py
@@ -116,13 +116,10 @@ def get_snowflake_to_hdfs_query(sf_location: AnyStr, sf_table_name: AnyStr,
     # things significantly easier to unit test.
 
     # Generate SELECT clause and cast TIMESTAMP_TZ, TIMESTAMP_LTZ to TIMESTAMP_NTZ
-    # Also cast TIMESTAMP because users can override TIMESTAMP to actually mean TIMESTAMP_TZ per
-    # documentation: https://docs.snowflake.com/en/sql-reference/parameters.html#client-timestamp-type-mapping
     # This is required as the COPY command does not support TZ and LTZ
-    timezoned_types = ['TIMESTAMPLTZ', 'TIMESTAMPTZ', 'TIMESTAMP']
     columns = [
         f'"{c["name"]}"'
-        + (f'::TIMESTAMP_NTZ AS "{c["name"]}"' if c['originalType'] in timezoned_types else '')
+        + (f'::TIMESTAMP_NTZ AS "{c["name"]}"' if c['originalType'] in ['TIMESTAMP_LTZ', 'TIMESTAMP_TZ'] else '')
         for c in sf_schema
     ]
 

--- a/python-lib/config.py
+++ b/python-lib/config.py
@@ -95,7 +95,7 @@ def get_snowflake_to_hdfs_query(sf_location: AnyStr, sf_table_name: AnyStr,
     # things significantly easier to unit test.
 
     # Generate SELECT clause and cast TIMESTAMP_TZ, TIMESTAMP_LTZ to TIMESTAMP
-    # This is required as COPY command does not support TZ and LTZ. See AOBS-491 for more details
+    # This is required as COPY command does not support TZ and LTZ
     columns = ''
     for col in sf_schema:
         columns += '"'+col['name']+'"'

--- a/python-lib/config.py
+++ b/python-lib/config.py
@@ -84,9 +84,9 @@ def get_hdfs_location(dataset_config: Mapping[AnyStr, Any], sf_stage_name: AnySt
 
 def get_table_schema_sql(sf_table_name: AnyStr) -> AnyStr:
     """
-        Generates SQL to extract table columns from DB
-        :param sf_table_name: Snowflake table in format of "schema"."table"
-        :return: SQL for getting table columns
+    Generates SQL to extract table columns from DB
+    :param sf_table_name: Snowflake table in format of "schema"."table". Note that schema and table are case-sensitive.
+    :return: SQL for getting table columns
     """
     tab = sf_table_name.replace('"', '')
     schema = tab.split('.')[0]

--- a/python-lib/config.py
+++ b/python-lib/config.py
@@ -94,11 +94,11 @@ def get_snowflake_to_hdfs_query(sf_location: AnyStr, sf_table_name: AnyStr,
     # moving this function here isn't strictly necessary as it's not re-used, but it makes
     # things significantly easier to unit test.
 
-    # Generate SELECT clause and cast TIMESTAMP_TZ, TIMESTAMP_LTZ to TIMESTAMP
+    # Generate SELECT clause and cast TIMESTAMP_TZ, TIMESTAMP_LTZ to TIMESTAMP_NTZ
     # This is required as the COPY command does not support TZ and LTZ
     columns = [
         f'"{c["name"]}"'
-        + (f'::TIMESTAMP AS "{c["name"]}"' if c['originalType'] in ['TIMESTAMPLTZ', 'TIMESTAMPTZ'] else '')
+        + (f'::TIMESTAMP_NTZ AS "{c["name"]}"' if c['originalType'] in ['TIMESTAMPLTZ', 'TIMESTAMPTZ'] else '')
         for c in sf_schema
     ]
 

--- a/python-lib/config.py
+++ b/python-lib/config.py
@@ -82,27 +82,25 @@ def get_hdfs_location(dataset_config: Mapping[AnyStr, Any], sf_stage_name: AnySt
     return f'{sf_stage_name}{path}/'
 
 
-def get_table_schema(sf_table_name: AnyStr, executor: Any) -> List[Mapping[AnyStr, AnyStr]]:
+def get_table_schema_sql(sf_table_name: AnyStr) -> AnyStr:
     """
-        For given table extracts list of columns and datatypes from DB
+        Generates SQL to extract table columns from DB
         :param sf_table_name: Snowflake table in format of "schema"."table"
-        :param executor: instance of dataiku.core.sql.SQLExecutor2
-        :return: List of dict records: [{'name': 'name', 'originalType': 'type'}...]
+        :return: SQL for getting table columns
     """
     tab = sf_table_name.replace('"', '')
     schema = tab.split('.')[0]
     table = tab.split('.')[1]
 
     sql = f'''
-    SELECT column_name AS "name", data_type AS "originalType"
-    FROM information_schema.columns
-    WHERE table_name = '{table}'
-    '''
+SELECT column_name AS "name", data_type AS "originalType"
+FROM information_schema.columns
+WHERE table_name = '{table}'
+'''
     if schema:
-        sql += f" AND table_schema = '{schema}'"
-    df = executor.query_to_df(sql)
-    result = df.to_dict('records')
-    return result
+        sql += f"  AND table_schema = '{schema}'"
+
+    return sql
 
 
 def get_snowflake_to_hdfs_query(sf_location: AnyStr, sf_table_name: AnyStr,

--- a/python-lib/config.py
+++ b/python-lib/config.py
@@ -95,8 +95,10 @@ def get_table_schema_sql(sf_table_name: AnyStr) -> AnyStr:
     sql = f'''
 SELECT column_name AS "name", data_type AS "originalType"
 FROM information_schema.columns
-WHERE table_name = '{table}' AND table_schema = '{schema}'
+WHERE table_name = '{table}'
 '''
+    if schema:
+        sql += f" AND table_schema = '{schema}'"
 
     return sql
 

--- a/python-lib/config.py
+++ b/python-lib/config.py
@@ -95,10 +95,8 @@ def get_table_schema_sql(sf_table_name: AnyStr) -> AnyStr:
     sql = f'''
 SELECT column_name AS "name", data_type AS "originalType"
 FROM information_schema.columns
-WHERE table_name = '{table}'
+WHERE table_name = '{table}' AND table_schema = '{schema}'
 '''
-    if schema:
-        sql += f"  AND table_schema = '{schema}'"
 
     return sql
 

--- a/python-lib/config.py
+++ b/python-lib/config.py
@@ -95,7 +95,7 @@ def get_snowflake_to_hdfs_query(sf_location: AnyStr, sf_table_name: AnyStr,
     # things significantly easier to unit test.
 
     # Generate SELECT clause and cast TIMESTAMP_TZ, TIMESTAMP_LTZ to TIMESTAMP
-    # This is required as COPY command does not support TZ and LTZ
+    # This is required as the COPY command does not support TZ and LTZ
     columns = [
         f'"{c["name"]}"'
         + (f'::TIMESTAMP AS "{c["name"]}"' if c['originalType'] in ['TIMESTAMPLTZ', 'TIMESTAMPTZ'] else '')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -249,7 +249,7 @@ class QueryCreationTests(ConfigTests):
         self.assertEqual(sql.strip(), f"""
 COPY INTO '{location}'
 FROM (
-    SELECT "col1"::TIMESTAMP AS "col1", "col2"::TIMESTAMP AS "col2", "col3"
+    SELECT "col1"::TIMESTAMP_NTZ AS "col1", "col2"::TIMESTAMP_NTZ AS "col2", "col3"
     FROM {table}
 )
 FILE_FORMAT = (TYPE = PARQUET)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -345,5 +345,23 @@ FORCE = TRUE;
             """.strip())
 
 
+class TableSchemaTests(ConfigTests):
+    def setUp(self):
+        self.result = f"""
+SELECT column_name AS "name", data_type AS "originalType"
+FROM information_schema.columns
+WHERE table_name = 'B'
+  AND table_schema = 'A'
+        """.strip()
+
+    def test_get_table_schema_sql_1(self):
+        sql = get_table_schema_sql('A.B')
+        self.assertEqual(sql.strip(), self.result)
+
+    def test_get_table_schema_sql_2(self):
+        sql = get_table_schema_sql('"A"."B"')
+        self.assertEqual(sql.strip(), self.result)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -354,11 +354,11 @@ WHERE table_name = 'B'
   AND table_schema = 'A'
         """.strip()
 
-    def test_get_table_schema_sql_1(self):
+    def test_get_table_schema_sql_no_quotes(self):
         sql = get_table_schema_sql('A.B')
         self.assertEqual(sql.strip(), self.result)
 
-    def test_get_table_schema_sql_2(self):
+    def test_get_table_schema_sql_quotes(self):
         sql = get_table_schema_sql('"A"."B"')
         self.assertEqual(sql.strip(), self.result)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -232,12 +232,23 @@ class QueryCreationTests(ConfigTests):
     def test_get_snowflake_to_hdfs_query_creates_query(self):
         location = '@STAGE_EXAMPLE/foo/bar/'
         table = '"SCHEMAGIC"."TABLELATOR"'
+        schema = [
+            {
+                'name': 'col1', 'originalType': 'TIMESTAMPLTZ'
+            },
+            {
+                'name': 'col2', 'originalType': 'TIMESTAMPTZ'
+            },
+            {
+                'name': 'col3', 'originalType': 'DATE'
+            }
+        ]
 
-        sql = get_snowflake_to_hdfs_query(location, table)
+        sql = get_snowflake_to_hdfs_query(location, table, schema)
 
         self.assertEqual(sql.strip(), f"""
 COPY INTO '{location}'
-FROM {table}
+FROM (SELECT "col1"::TIMESTAMP AS "col1","col2"::TIMESTAMP AS "col2","col3" FROM {table})
 FILE_FORMAT = (TYPE = PARQUET)
 OVERWRITE = TRUE
 HEADER = TRUE;

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -248,7 +248,10 @@ class QueryCreationTests(ConfigTests):
 
         self.assertEqual(sql.strip(), f"""
 COPY INTO '{location}'
-FROM (SELECT "col1"::TIMESTAMP AS "col1","col2"::TIMESTAMP AS "col2","col3" FROM {table})
+FROM (
+    SELECT "col1"::TIMESTAMP AS "col1", "col2"::TIMESTAMP AS "col2", "col3"
+    FROM {table}
+)
 FILE_FORMAT = (TYPE = PARQUET)
 OVERWRITE = TRUE
 HEADER = TRUE;

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -350,8 +350,7 @@ class TableSchemaTests(ConfigTests):
         self.result = f"""
 SELECT column_name AS "name", data_type AS "originalType"
 FROM information_schema.columns
-WHERE table_name = 'B'
-  AND table_schema = 'A'
+WHERE table_name = 'B' AND table_schema = 'A'
         """.strip()
 
     def test_get_table_schema_sql_no_quotes(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -346,20 +346,22 @@ FORCE = TRUE;
 
 
 class TableSchemaTests(ConfigTests):
-    def setUp(self):
-        self.result = f"""
+    def test_get_table_schema_sql_no_schema(self):
+        sql = get_table_schema_sql('""."B"')
+        self.assertEqual(sql.strip(), f"""
 SELECT column_name AS "name", data_type AS "originalType"
 FROM information_schema.columns
-WHERE table_name = 'B' AND table_schema = 'A'
-        """.strip()
+WHERE table_name = 'B'
+        """.strip())
 
-    def test_get_table_schema_sql_no_quotes(self):
-        sql = get_table_schema_sql('A.B')
-        self.assertEqual(sql.strip(), self.result)
-
-    def test_get_table_schema_sql_quotes(self):
+    def test_get_table_schema_sql_with_schema(self):
         sql = get_table_schema_sql('"A"."B"')
-        self.assertEqual(sql.strip(), self.result)
+        self.assertEqual(sql.strip(), f"""
+SELECT column_name AS "name", data_type AS "originalType"
+FROM information_schema.columns
+WHERE table_name = 'B'
+ AND table_schema = 'A'
+        """.strip())
 
 
 if __name__ == '__main__':

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -260,16 +260,13 @@ HEADER = TRUE;
     def test_get_snowflake_to_hdfs_query_casts_columns(self):
         schema = [
             {
-                'name': 'col1', 'originalType': 'TIMESTAMPLTZ'
+                'name': 'col1', 'originalType': 'TIMESTAMP_LTZ'
             },
             {
-                'name': 'col2', 'originalType': 'TIMESTAMPTZ'
+                'name': 'col2', 'originalType': 'TIMESTAMP_TZ'
             },
             {
                 'name': 'col3', 'originalType': 'DATE'
-            },
-            {
-                'name': 'col4', 'originalType': 'TIMESTAMP'
             },
             {
                 'name': 'col5', 'originalType': 'VARCHAR'
@@ -285,9 +282,8 @@ HEADER = TRUE;
         expected_columns = f'"{schema[0]["name"]}"::TIMESTAMP_NTZ AS "{schema[0]["name"]}", ' \
                            f'"{schema[1]["name"]}"::TIMESTAMP_NTZ AS "{schema[1]["name"]}", ' \
                            f'"{schema[2]["name"]}", ' \
-                           f'"{schema[3]["name"]}"::TIMESTAMP_NTZ AS "{schema[3]["name"]}", ' \
-                           f'"{schema[4]["name"]}", ' \
-                           f'"{schema[5]["name"]}"'
+                           f'"{schema[3]["name"]}", ' \
+                           f'"{schema[4]["name"]}"'
 
         self.assertRegex(sql, re.escape(expected_columns))
 


### PR DESCRIPTION
+ Fixed TIMESTAMP_LTZ and TIMESTAMP_TZ type names
+ TIMESTAMP is removed as it is just an alias and is internally converted to actual type. See https://docs.snowflake.com/en/sql-reference/data-types-datetime.html#timestamp for more details