### PR TITLE
AOBS-491: fix for Dataiku TIMESTAMP_LTZ and TIMESTAMP_TZ types

### DIFF
--- a/python-lib/config.py
+++ b/python-lib/config.py
@@ -116,13 +116,10 @@ def get_snowflake_to_hdfs_query(sf_location: AnyStr, sf_table_name: AnyStr,
     # things significantly easier to unit test.
 
     # Generate SELECT clause and cast TIMESTAMP_TZ, TIMESTAMP_LTZ to TIMESTAMP_NTZ
-    # Also cast TIMESTAMP because users can override TIMESTAMP to actually mean TIMESTAMP_TZ per
-    # documentation: https://docs.snowflake.com/en/sql-reference/parameters.html#client-timestamp-type-mapping
     # This is required as the COPY command does not support TZ and LTZ
-    timezoned_types = ['TIMESTAMPLTZ', 'TIMESTAMPTZ', 'TIMESTAMP']
     columns = [
         f'"{c["name"]}"'
-        + (f'::TIMESTAMP_NTZ AS "{c["name"]}"' if c['originalType'] in timezoned_types else '')
+        + (f'::TIMESTAMP_NTZ AS "{c["name"]}"' if c['originalType'] in ['TIMESTAMP_LTZ', 'TIMESTAMP_TZ'] else '')
         for c in sf_schema
     ]
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -260,16 +260,13 @@ HEADER = TRUE;
     def test_get_snowflake_to_hdfs_query_casts_columns(self):
         schema = [
             {
-                'name': 'col1', 'originalType': 'TIMESTAMPLTZ'
+                'name': 'col1', 'originalType': 'TIMESTAMP_LTZ'
             },
             {
-                'name': 'col2', 'originalType': 'TIMESTAMPTZ'
+                'name': 'col2', 'originalType': 'TIMESTAMP_TZ'
             },
             {
                 'name': 'col3', 'originalType': 'DATE'
-            },
-            {
-                'name': 'col4', 'originalType': 'TIMESTAMP'
             },
             {
                 'name': 'col5', 'originalType': 'VARCHAR'
@@ -285,9 +282,8 @@ HEADER = TRUE;
         expected_columns = f'"{schema[0]["name"]}"::TIMESTAMP_NTZ AS "{schema[0]["name"]}", ' \
                            f'"{schema[1]["name"]}"::TIMESTAMP_NTZ AS "{schema[1]["name"]}", ' \
                            f'"{schema[2]["name"]}", ' \
-                           f'"{schema[3]["name"]}"::TIMESTAMP_NTZ AS "{schema[3]["name"]}", ' \
-                           f'"{schema[4]["name"]}", ' \
-                           f'"{schema[5]["name"]}"'
+                           f'"{schema[3]["name"]}", ' \
+                           f'"{schema[4]["name"]}"'
 
         self.assertRegex(sql, re.escape(expected_columns))
 


### PR DESCRIPTION
Fixed TIMESTAMP_LTZ and TIMESTAMP_TZ type names
TIMESTAMP is removed as it is just an alias and is internally converted to actual type. 
See https://docs.snowflake.com/en/sql-reference/data-types-datetime.html#timestamp for more details