### PR TITLE
fix(AOBS-491): Use native sfType instead of originalType, and fix schema-less tables

### DIFF
--- a/python-lib/config.py
+++ b/python-lib/config.py
@@ -95,6 +95,8 @@ def get_table_schema_sql(sf_table_name: AnyStr) -> AnyStr:
     :return: SQL for getting table columns
     """
 
+    # finds a quoted table name and, optionally, a schema prefix
+    # see tests for example inputs
     tbl_sch_re = re.search(r'("?(?P<schema>[^"]+)"?\.)?"?(?P<table>[^"]+)"?', sf_table_name)
 
     schema_clause = f'AND table_schema = \'{tbl_sch_re.group("schema")}\'' if tbl_sch_re.group('schema') else ''

--- a/python-lib/config.py
+++ b/python-lib/config.py
@@ -122,12 +122,10 @@ def get_snowflake_to_hdfs_query(sf_location: AnyStr, sf_table_name: AnyStr,
     # things significantly easier to unit test.
 
     # Generate SELECT clause and cast TIMESTAMP_TZ, TIMESTAMP_LTZ to TIMESTAMP_NTZ
-    # Also cast TIMESTAMP because users can override TIMESTAMP to actually mean TIMESTAMP_TZ per
-    # documentation: https://docs.snowflake.com/en/sql-reference/parameters.html#client-timestamp-type-mapping
     # This is required as the COPY command does not support TZ and LTZ
-    timezoned_types = ['TIMESTAMPLTZ', 'TIMESTAMPTZ', 'TIMESTAMP']
     columns = [
-        f'"{c["name"]}"' + (f'::TIMESTAMP_NTZ AS "{c["name"]}"' if c['originalType'] in timezoned_types else '')
+        f'"{c["name"]}"'
+        + (f'::TIMESTAMP_NTZ AS "{c["name"]}"' if c['originalType'] in ['TIMESTAMP_LTZ', 'TIMESTAMP_TZ'] else '')
         for c in sf_schema
     ]
 

--- a/python-lib/config.py
+++ b/python-lib/config.py
@@ -54,7 +54,7 @@ def get_table_name(dataset_config: Mapping[AnyStr, Any]) -> AnyStr:
 
     table_name = f'"{params["table"]}"'
 
-    if 'schema' in params:
+    if params.get('schema', ''):
         table_name = f'"{params["schema"]}".{table_name}'
 
     return table_name.replace('${projectKey}', project_key)

--- a/python-lib/config.py
+++ b/python-lib/config.py
@@ -84,19 +84,21 @@ def get_hdfs_location(dataset_config: Mapping[AnyStr, Any], sf_stage_name: AnySt
 
 def get_table_schema_sql(sf_table_name: AnyStr) -> AnyStr:
     """
-    Generates SQL to extract table columns from DB
-    :param sf_table_name: Snowflake table in format of "schema"."table". Note that schema and table are case-sensitive.
+    Generates SQL to extract a table's schema
+    :param sf_table_name: Snowflake table in format of "schema"."table"
     :return: SQL for getting table columns
     """
     tab = sf_table_name.replace('"', '')
     schema = tab.split('.')[0]
     table = tab.split('.')[1]
 
+    # Dataiku's `originalType` parameter is Snowflake's data_type but without `_`
     sql = f'''
-SELECT column_name AS "name", data_type AS "originalType"
+SELECT column_name AS "name", REPLACE(data_type, '_', '') AS "originalType"
 FROM information_schema.columns
 WHERE table_name = '{table}'
-'''
+    '''
+
     if schema:
         sql += f" AND table_schema = '{schema}'"
 

--- a/python-lib/config.py
+++ b/python-lib/config.py
@@ -123,7 +123,7 @@ def get_snowflake_to_hdfs_query(sf_location: AnyStr, sf_table_name: AnyStr,
     # This is required as the COPY command does not support TZ and LTZ
     timezoned_types = ['TIMESTAMPLTZ', 'TIMESTAMPTZ', 'TIMESTAMP']
     columns = [
-        f'"{c["name"]}"'(f'::TIMESTAMP_NTZ AS "{c["name"]}"' if c['originalType'] in timezoned_types else '')
+        f'"{c["name"]}"' + (f'::TIMESTAMP_NTZ AS "{c["name"]}"' if c['originalType'] in timezoned_types else '')
         for c in sf_schema
     ]
 

--- a/python-lib/config.py
+++ b/python-lib/config.py
@@ -93,11 +93,11 @@ def get_table_schema_sql(sf_table_name: AnyStr) -> AnyStr:
     table = tab.split('.')[1]
 
     # Dataiku's `originalType` parameter is Snowflake's data_type but without `_`
-    sql = f'''
+    sql = f"""
 SELECT column_name AS "name", REPLACE(data_type, '_', '') AS "originalType"
 FROM information_schema.columns
 WHERE table_name = '{table}'
-    '''
+    """
 
     if schema:
         sql += f" AND table_schema = '{schema}'"
@@ -123,8 +123,7 @@ def get_snowflake_to_hdfs_query(sf_location: AnyStr, sf_table_name: AnyStr,
     # This is required as the COPY command does not support TZ and LTZ
     timezoned_types = ['TIMESTAMPLTZ', 'TIMESTAMPTZ', 'TIMESTAMP']
     columns = [
-        f'"{c["name"]}"'
-        + (f'::TIMESTAMP_NTZ AS "{c["name"]}"' if c['originalType'] in timezoned_types else '')
+        f'"{c["name"]}"'(f'::TIMESTAMP_NTZ AS "{c["name"]}"' if c['originalType'] in timezoned_types else '')
         for c in sf_schema
     ]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [metadate]
 license_file = LICENSE
 
-[pycodestyle]
-exclude = ./venv-py/
+[flake8]
+ignore = W605, F401, F403, F405
 max-line-length = 120
+inline-quotes = single
+statistics = True
+exclude = venv-py,build,dist,.git,__pycache__,lib

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -139,6 +139,19 @@ class TableNameTests(ConfigTests):
 
         self.assertEqual(table_name, f'"{input_schema}"."{input_table}"')
 
+    def test_get_table_name_quotes_and_concatenates_table(self):
+        input_table = 'My Table Name'
+        table_name = get_table_name({
+            'type': 'Snowflake',
+            'projectKey': 'SOME_PROJECT',
+            'params': {
+                'mode': 'table',
+                'table': input_table
+            }
+        })
+
+        self.assertEqual(table_name, f'"{input_table}"')
+
 
 class HdfsLocationTests(ConfigTests):
 
@@ -346,7 +359,7 @@ FORCE = TRUE;
 class TableSchemaTests(ConfigTests):
 
     def test_get_table_schema_sql_no_schema(self):
-        sql = get_table_schema_sql('""."B"')
+        sql = get_table_schema_sql('"B"')
         self.assertEqual(sql.strip(), """
 SELECT column_name AS "name", REPLACE(data_type, '_', '') AS "originalType"
 FROM information_schema.columns
@@ -358,8 +371,7 @@ WHERE table_name = 'B'
         self.assertEqual(sql.strip(), """
 SELECT column_name AS "name", REPLACE(data_type, '_', '') AS "originalType"
 FROM information_schema.columns
-WHERE table_name = 'B'
-     AND table_schema = 'A'
+WHERE table_name = 'B' AND table_schema = 'A'
         """.strip())
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -282,16 +282,13 @@ HEADER = TRUE;
     def test_get_snowflake_to_hdfs_query_casts_columns(self):
         schema = [
             {
-                'name': 'col1', 'originalType': 'TIMESTAMPLTZ'
+                'name': 'col1', 'originalType': 'TIMESTAMP_LTZ'
             },
             {
-                'name': 'col2', 'originalType': 'TIMESTAMPTZ'
+                'name': 'col2', 'originalType': 'TIMESTAMP_TZ'
             },
             {
                 'name': 'col3', 'originalType': 'DATE'
-            },
-            {
-                'name': 'col4', 'originalType': 'TIMESTAMP'
             },
             {
                 'name': 'col5', 'originalType': 'VARCHAR'
@@ -307,9 +304,8 @@ HEADER = TRUE;
         expected_columns = f'"{schema[0]["name"]}"::TIMESTAMP_NTZ AS "{schema[0]["name"]}", ' \
                            f'"{schema[1]["name"]}"::TIMESTAMP_NTZ AS "{schema[1]["name"]}", ' \
                            f'"{schema[2]["name"]}", ' \
-                           f'"{schema[3]["name"]}"::TIMESTAMP_NTZ AS "{schema[3]["name"]}", ' \
-                           f'"{schema[4]["name"]}", ' \
-                           f'"{schema[5]["name"]}"'
+                           f'"{schema[3]["name"]}", ' \
+                           f'"{schema[4]["name"]}"'
 
         self.assertRegex(sql, re.escape(expected_columns))
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -111,6 +111,9 @@ class TableNameTests(ConfigTests):
             })
 
     def test_get_table_name_replaces_project_key(self):
+        """
+        Tests table and schema names that include the `${projectKey}` replacement variable
+        """
         project_key = 'SOME_PROJECT'
         table_name = get_table_name({
             'type': 'Snowflake',
@@ -125,6 +128,9 @@ class TableNameTests(ConfigTests):
         self.assertRegex(table_name, re.escape(project_key))
 
     def test_get_table_name_quotes_and_concatenates_table_and_schema(self):
+        """
+        Tests table name and schema name
+        """
         input_table = 'My Table Name'
         input_schema = 'SCHEMAGIC'
         table_name = get_table_name({
@@ -139,7 +145,10 @@ class TableNameTests(ConfigTests):
 
         self.assertEqual(table_name, f'"{input_schema}"."{input_table}"')
 
-    def test_get_table_name_quotes_and_concatenates_table(self):
+    def test_get_table_name_quotes_table(self):
+        """
+        Tests table name without schema
+        """
         input_table = 'My Table Name'
         table_name = get_table_name({
             'type': 'Snowflake',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -256,13 +256,13 @@ class QueryCreationTests(ConfigTests):
         table = '"SCHEMAGIC"."TABLELATOR"'
         schema = [
             {
-                'name': 'col1', 'originalType': 'VARCHAR'
+                'name': 'col1', 'sfType': 'VARCHAR'
             },
             {
-                'name': 'col2', 'originalType': 'DATE'
+                'name': 'col2', 'sfType': 'DATE'
             },
             {
-                'name': 'col3', 'originalType': 'BOOLEAN'
+                'name': 'col3', 'sfType': 'BOOLEAN'
             }
         ]
 
@@ -282,20 +282,20 @@ HEADER = TRUE;
     def test_get_snowflake_to_hdfs_query_casts_columns(self):
         schema = [
             {
-                'name': 'col1', 'originalType': 'TIMESTAMP_LTZ'
+                'name': 'col1', 'sfType': 'TIMESTAMP_LTZ'
             },
             {
-                'name': 'col2', 'originalType': 'TIMESTAMP_TZ'
+                'name': 'col2', 'sfType': 'TIMESTAMP_TZ'
             },
             {
-                'name': 'col3', 'originalType': 'DATE'
+                'name': 'col3', 'sfType': 'DATE'
             },
             {
-                'name': 'col5', 'originalType': 'VARCHAR'
+                'name': 'col5', 'sfType': 'VARCHAR'
             },
             {
                 # Alias for TIMESTAMP_NTZ https://docs.snowflake.com/en/sql-reference/data-types-datetime.html#datetime
-                'name': 'col6', 'originalType': 'DATETIME'
+                'name': 'col6', 'sfType': 'DATETIME'
             }
         ]
 
@@ -366,7 +366,7 @@ class TableSchemaTests(ConfigTests):
     def test_get_table_schema_sql_no_schema(self):
         sql = get_table_schema_sql('"B"')
         self.assertEqual(sql.strip(), """
-SELECT column_name AS "name", REPLACE(data_type, '_', '') AS "originalType"
+SELECT column_name AS "name", data_type AS "sfType"
 FROM information_schema.columns
 WHERE table_name = 'B'
         """.strip())
@@ -374,7 +374,7 @@ WHERE table_name = 'B'
     def test_get_table_schema_sql_with_schema(self):
         sql = get_table_schema_sql('"A"."B"')
         self.assertEqual(sql.strip(), """
-SELECT column_name AS "name", REPLACE(data_type, '_', '') AS "originalType"
+SELECT column_name AS "name", data_type AS "sfType"
 FROM information_schema.columns
 WHERE table_name = 'B' AND table_schema = 'A'
         """.strip())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -346,10 +346,11 @@ FORCE = TRUE;
 
 
 class TableSchemaTests(ConfigTests):
+
     def test_get_table_schema_sql_no_schema(self):
         sql = get_table_schema_sql('""."B"')
         self.assertEqual(sql.strip(), f"""
-SELECT column_name AS "name", data_type AS "originalType"
+SELECT column_name AS "name", REPLACE(data_type, '_', '') AS "originalType"
 FROM information_schema.columns
 WHERE table_name = 'B'
         """.strip())
@@ -357,10 +358,10 @@ WHERE table_name = 'B'
     def test_get_table_schema_sql_with_schema(self):
         sql = get_table_schema_sql('"A"."B"')
         self.assertEqual(sql.strip(), f"""
-SELECT column_name AS "name", data_type AS "originalType"
+SELECT column_name AS "name", REPLACE(data_type, '_', '') AS "originalType"
 FROM information_schema.columns
 WHERE table_name = 'B'
- AND table_schema = 'A'
+     AND table_schema = 'A'
         """.strip())
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -75,11 +75,11 @@ class ConnectionNameTests(ConfigTests):
 
         with self.assertRaises(ValueError) as cm:
             _ = get_connection_name({
-                    'type': bad_type,
-                    'params': {
-                        'connection': 'BAZ'
-                    }
-                })
+                'type': bad_type,
+                'params': {
+                    'connection': 'BAZ'
+                }
+            })
 
         self._assert_invalid_type_exception(cm.exception, bad_type, 'Snowflake')
 
@@ -113,14 +113,14 @@ class TableNameTests(ConfigTests):
     def test_get_table_name_replaces_project_key(self):
         project_key = 'SOME_PROJECT'
         table_name = get_table_name({
-                'type': 'Snowflake',
-                'projectKey': project_key,
-                'params': {
-                    'mode': 'table',
-                    'table': 'Foo${projectKey}Bar',
-                    'schema': '${projectKey}blah'
-                }
-            })
+            'type': 'Snowflake',
+            'projectKey': project_key,
+            'params': {
+                'mode': 'table',
+                'table': 'Foo${projectKey}Bar',
+                'schema': '${projectKey}blah'
+            }
+        })
         self.assertNotRegex(table_name, re.escape('${projectKey}'))
         self.assertRegex(table_name, re.escape(project_key))
 
@@ -224,7 +224,7 @@ class HdfsLocationTests(ConfigTests):
             }
         }
         location = get_hdfs_location(config, 'some_stage')
-        self.assertRegex(location, f'/$')
+        self.assertRegex(location, '/$')
 
 
 class QueryCreationTests(ConfigTests):
@@ -291,9 +291,7 @@ HEADER = TRUE;
 
         self.assertRegex(sql, re.escape(expected_columns))
 
-
     def test_get_hdfs_to_snowflake_query_requires_a_column(self):
-
         with self.assertRaisesRegex(ValueError, 'must have at least one column'):
             _ = get_hdfs_to_snowflake_query('@some_location', '"SOME"."TABLE"', [])
 
@@ -349,7 +347,7 @@ class TableSchemaTests(ConfigTests):
 
     def test_get_table_schema_sql_no_schema(self):
         sql = get_table_schema_sql('""."B"')
-        self.assertEqual(sql.strip(), f"""
+        self.assertEqual(sql.strip(), """
 SELECT column_name AS "name", REPLACE(data_type, '_', '') AS "originalType"
 FROM information_schema.columns
 WHERE table_name = 'B'
@@ -357,7 +355,7 @@ WHERE table_name = 'B'
 
     def test_get_table_schema_sql_with_schema(self):
         sql = get_table_schema_sql('"A"."B"')
-        self.assertEqual(sql.strip(), f"""
+        self.assertEqual(sql.strip(), """
 SELECT column_name AS "name", REPLACE(data_type, '_', '') AS "originalType"
 FROM information_schema.columns
 WHERE table_name = 'B'


### PR DESCRIPTION
This PR fixes the issue with unscores in the `originalType` parameter while keeping true to the intent of `originalType`.

It also applies flake8 formatting rules.

Fixes #19 

Closes #18